### PR TITLE
[COOK-1174] Ensure resource is always available

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,13 +31,15 @@ end
 
 rd.run_action(:create)
 
+resource = ohai 'custom_plugins' do
+  action :nothing
+end
+
 # only reload ohai if new plugins were dropped off OR
 # node['ohai']['plugin_path'] does not exists in client.rb
 if rd.updated? || 
   !(::IO.read(Chef::Config[:config_file]) =~ /Ohai::Config\[:plugin_path\]\s*<<\s*["']#{node['ohai']['plugin_path']}["']/)
 
-  ohai 'custom_plugins' do
-    action :nothing
-  end.run_action(:reload)
+  resource.run_action(:reload)
 
 end


### PR DESCRIPTION
Make custom_plugins ohai resource always available. Limit the conditional block to only the reload action.
