### PR TITLE
COOK-1383: Allow to install Ohai plugins from other cookbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Attributes
 
 Neither an FHS location or the default value of this attribute are in the default Ohai plugin path. Set the Ohai plugin path with the config setting "`Ohai::Config[:plugin_path]`" in the Chef config file (the `chef::config` recipe does this automatically for you!). The attribute is not set to the default plugin path that Ohai ships with because we don't want to risk destroying existing essential plugins for Ohai.
 
+`node['ohai']['plugins']` - sources of plugins, defaults to the `files/default/plugins` directory of this cookbook. You can add additional cookbooks by adding the name of the cookbook as a key and the path of the files directory as the value. You have to make sure that you don't have any file conflicts between multiple cookbooks. The last one to write wins.
+
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,6 @@
 
 # FHS location would be /var/lib/chef/ohai_plugins or similar.
 default["ohai"]["plugin_path"] = "/etc/chef/ohai_plugins"
+
+# The list of plugins and their respective file locations
+default["ohai"]["plugins"] = {'ohai' => 'plugins'}

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,3 +13,10 @@ attribute "ohai/plugin_path",
   :type => "string",
   :required => "optional",
   :default => "/etc/chef/ohai_plugins"
+
+attribute "ohai/plugins",
+  :display_name => "Ohai Plugin Sources",
+  :description => "Read plugins from these cookbooks and paths",
+  :type => "hash",
+  :required => "optional",
+  :default => {'ohai' => 'plugins'}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,16 +20,22 @@
 Ohai::Config[:plugin_path] << node['ohai']['plugin_path']
 Chef::Log.info("ohai plugins will be at: #{node['ohai']['plugin_path']}")
 
-rd = remote_directory node['ohai']['plugin_path'] do
-  source 'plugins'
-  owner 'root'
-  group 'root'
-  mode 0755
-  recursive true
-  action :nothing
-end
+reload_ohai = false
+node['ohai']['plugins'].each_pair do |source_cookbook, path|
+  rd = remote_directory node['ohai']['plugin_path'] do
+    cookbook source_cookbook
+    source path
+    owner 'root'
+    group 'root'
+    mode '0755'
+    recursive true
+    purge false
+    action :nothing
+  end
 
-rd.run_action(:create)
+  rd.run_action(:create)
+  reload_ohai ||= rd.updated?
+end
 
 resource = ohai 'custom_plugins' do
   action :nothing
@@ -37,9 +43,8 @@ end
 
 # only reload ohai if new plugins were dropped off OR
 # node['ohai']['plugin_path'] does not exists in client.rb
-if rd.updated? || 
+if reload_ohai ||
   !(::IO.read(Chef::Config[:config_file]) =~ /Ohai::Config\[:plugin_path\]\s*<<\s*["']#{node['ohai']['plugin_path']}["']/)
 
   resource.run_action(:reload)
-
 end


### PR DESCRIPTION
Allow to install Ohai plugins from other cookbooks. This the implementation for http://tickets.opscode.com/browse/COOK-1383
