### PR TITLE
[COOK-1424] Ohai::Config[:plugin_path] increase to infinity

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-Ohai::Config[:plugin_path] << node['ohai']['plugin_path']
+unless Ohai::Config[:plugin_path].include?(node['ohai']['plugin_path'])
+  Ohai::Config[:plugin_path] << node['ohai']['plugin_path']
+end
 Chef::Log.info("ohai plugins will be at: #{node['ohai']['plugin_path']}")
 
 reload_ohai = false


### PR DESCRIPTION
In each execute of chef-client, when this it's demonized, the ohai plugins path added to Ohai::Config[:plugin_path].
Then this array increase to infinity.
