### PR TITLE
Patch for COOK-2096

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,12 @@
 #
 
 # FHS location would be /var/lib/chef/ohai_plugins or similar.
-default["ohai"]["plugin_path"] = "/etc/chef/ohai_plugins"
+case node["platform_family"]
+when "windows"
+	default["ohai"]["plugin_path"] = "C:/chef/ohai_plugins"
+else
+	default["ohai"]["plugin_path"] = "/etc/chef/ohai_plugins"
+end
 
 # The list of plugins and their respective file locations
 default["ohai"]["plugins"]["ohai"] = "plugins"


### PR DESCRIPTION
Added support for a Windows-compatible default path in the default attributes file.
