### PR TITLE
[COOK-3091] Check that Chef::Config[:config_file] is set before using it

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,8 @@ end
 # only reload ohai if new plugins were dropped off OR
 # node['ohai']['plugin_path'] does not exists in client.rb
 if reload_ohai ||
-  !(::IO.read(Chef::Config[:config_file]) =~ /Ohai::Config\[:plugin_path\]\s*<<\s*["']#{node['ohai']['plugin_path']}["']/)
+  !(Chef::Config[:config_file] &&
+    ::IO.read(Chef::Config[:config_file]) =~ /Ohai::Config\[:plugin_path\]\s*<<\s*["']#{node['ohai']['plugin_path']}["']/)
 
   resource.run_action(:reload)
 end


### PR DESCRIPTION
Ticket: http://tickets.opscode.com/browse/COOK-3091

At least on some ChefSpec setups the `Chef::Config[:config_file]` seems to be `nil` and then `IO.read` raises an exception.
