### PR TITLE
Updated default attribute for Windows plugin path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 # FHS location would be /var/lib/chef/ohai_plugins or similar.
 case node["platform_family"]
 when "windows"
-	default["ohai"]["plugin_path"] = "C:/chef/ohai_plugins"
+	default["ohai"]["plugin_path"] = "#{ENV['systemdrive']}/chef/ohai_plugins"
 else
 	default["ohai"]["plugin_path"] = "/etc/chef/ohai_plugins"
 end


### PR DESCRIPTION
Updated the default attributes file to use the Windows %systemdrive% environment variable instead of being hard coded to C:.  We found several Windows hosts in our environment that had the system drive set as a different letter.  Tested on 2003, 2008, and 2012.