### PR TITLE
Update hint.rb to use use_inline_resources only iff it's available

### DIFF
--- a/providers/hint.rb
+++ b/providers/hint.rb
@@ -6,7 +6,7 @@ def build_ohai_hint_path
   ::File.join(node[:ohai][:hints_path], "#{new_resource.name}.json")
 end
 
-use_inline_resources
+use_inline_resources if defined? use_inline_resources
 
 action :create do
   if @current_resource.content != new_resource.content


### PR DESCRIPTION
Only use use_inline_resources if it's available. 
Vagrant uses Chef 10.14.2 which breaks horribly on encountering use_inline_resources
See https://gist.github.com/labeneator/227f3f496afb27a7175c