### PR TITLE
Fix when empty content is provided, and fix updated behavior

### DIFF
--- a/providers/hint.rb
+++ b/providers/hint.rb
@@ -1,4 +1,5 @@
-def why_run_supported?
+def whyrun_supported?
+  # rely on the whyrun support of the resources
   true
 end
 
@@ -9,27 +10,20 @@ end
 use_inline_resources
 
 action :create do
-  if @current_resource.content != new_resource.content
-    directory node[:ohai][:hints_path] do
-      action :create
-      recursive true
-    end
+  updated = false
 
-    file build_ohai_hint_path do
-      action :create
-      content JSON.pretty_generate(new_resource.content)
-    end
-  end
-end
-
-
-def load_current_resource
-  @current_resource = Chef::Resource::OhaiHint.new(new_resource.name)
-  if ::File.exist?(build_ohai_hint_path)
-    @current_resource.content(JSON.parse(::File.read(build_ohai_hint_path)))
-  else
-    @current_resource.content(nil)
+  r = directory node[:ohai][:hints_path] do
+    action :create
+    recursive true
   end
 
-  @current_resource
+  updated = r.updated_by_last_action?
+
+  r = file build_ohai_hint_path do
+    action :create
+    content JSON.pretty_generate(new_resource.content)
+  end
+
+  updated = updated or r.updated_by_last_action?
+  new_resource.updated_by_last_action(updated)
 end

--- a/resources/hint.rb
+++ b/resources/hint.rb
@@ -1,6 +1,5 @@
 actions :create, :delete
 default_action :create
 
-
 attribute :hint_name, :kind_of => String, :name_attribute => true
 attribute :content, :kind_of => Hash, :default => {}


### PR DESCRIPTION
When you simply want to create an empty hint (e.g. for EC2) and the hint
doesn't yet exist with non-empty content, it will report as up to date
because of a bad check on the content.

The content check could've been fixed, but I'd rather rely on the
resources just doing their thing instead. This simplifies the LWRP
considerably and also improves the reporting of whether anything was
actually done.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chef-cookbooks/ohai/20)
<!-- Reviewable:end -->
