### PR TITLE
Validate the hint format before using it

### DIFF
--- a/providers/hint.rb
+++ b/providers/hint.rb
@@ -22,11 +22,14 @@ action :create do
   end
 end
 
-
 def load_current_resource
   @current_resource = Chef::Resource::OhaiHint.new(new_resource.name)
   if ::File.exist?(build_ohai_hint_path)
-    @current_resource.content(JSON.parse(::File.read(build_ohai_hint_path)))
+    begin
+      @current_resource.content(JSON.parse(::File.read(build_ohai_hint_path)))
+    rescue JSON::ParserError
+      @current_resource.content(nil)
+    end
   else
     @current_resource.content(nil)
   end


### PR DESCRIPTION
Hey,

The idea behind that is sometimes the hint file could be corrupted with that you make sure the ohai_hint would fail but dump a new clean hint file.

Regards,
JM