### PR TITLE
Fix when empty content is provided, and fix updated behavior

### DIFF
--- a/providers/hint.rb
+++ b/providers/hint.rb
@@ -1,4 +1,5 @@
-def why_run_supported?
+def whyrun_supported?
+  # rely on the whyrun support of the resources
   true
 end
 
@@ -9,17 +10,20 @@ end
 use_inline_resources
 
 action :create do
-  if @current_resource.content != new_resource.content
-    directory node['ohai']['hints_path'] do
-      action :create
-      recursive true
-    end
-
-    file build_ohai_hint_path do
-      action :create
-      content JSON.pretty_generate(new_resource.content)
-    end
+  r = directory node['ohai']['hints_path'] do
+    action :create
+    recursive true
   end
+
+  updated = r.updated_by_last_action?
+
+  r = file build_ohai_hint_path do
+    action :create
+    content JSON.pretty_generate(new_resource.content)
+  end
+
+  updated = updated or r.updated_by_last_action?
+  new_resource.updated_by_last_action(updated)
 end
 
 def load_current_resource


### PR DESCRIPTION
When you simply want to create an empty hint (e.g. for EC2) and the hint
doesn't yet exist with non-empty content, it will report as up to date
because of a bad check on the content.

The content check could've been fixed, but I'd rather rely on the
resources just doing their thing instead. This simplifies the LWRP
considerably and also improves the reporting of whether anything was
actually done.

Supersedes #20