### PR TITLE
backport a fix from 3.x branch to resolve noise in chefspec tests

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,8 +20,8 @@
 reload_ohai = false
 # Add plugin_path from node attributes if missing, and ensure a reload of
 # ohai in that case
-unless Ohai::Config[:plugin_path].include?(node['ohai']['plugin_path'])
-  Ohai::Config[:plugin_path] = [node['ohai']['plugin_path'], Ohai::Config[:plugin_path]].flatten.compact
+unless Ohai.config[:plugin_path].include?(node['ohai']['plugin_path'])
+  Ohai.config[:plugin_path] = [node['ohai']['plugin_path'], Ohai.config[:plugin_path]].flatten.compact
   reload_ohai ||= true
 end
 Chef::Log.info("ohai plugins will be at: #{node['ohai']['plugin_path']}")


### PR DESCRIPTION
### Description

This just backports a small change from 3.x to 2.x.  The result is less deprecation noise in chefspec tests.  Because many community cookbook still depend on the 2.x branch, we are not able to move to 3.x at this time.

### Issues Resolved

### Check List
- [X ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ N/A] New functionality includes testing.
- [ N/A] New functionality has been documented in the README if applicable
- [ X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


