### PR TITLE
Fix plugin file compatability with windows

### DIFF
--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -75,9 +75,6 @@ action :create do
 
   cookbook_file ::File.join(desired_plugin_path, new_resource.plugin_name + '.rb') do
     source new_resource.source_file || "#{new_resource.plugin_name}.rb"
-    owner 'root'
-    group 'root'
-    mode 00644
     notifies :reload, "ohai[#{new_resource.plugin_name}]", :immediately
   end
 


### PR DESCRIPTION
### Description

Removes owner/group/mode from the file resource for creating plugins. Was hard coded to linux root user and group. File resource defaults to root on linux and defaults to system on windows so removing the lines lets the file resource assign the appropriate permissions based on platform.

### Issues Resolved

#41 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


