### PR TITLE
Allow templates as Ohai plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Installs custom Ohai plugins.
 #### Resource Attributes
 
 - `plugin_name` - The name to give the plugin on the filesystem. Should be string, default is name of resource.
-- `path` - The path to your custom plugin directory. Defaults to a directory named 'ohai_plugins' in the Chef config dir
-- `source_file` - The source file for the plugin in your cookbook if not NAME.rb
-- `compile_time` - Should the resource run at compile time. This defaults to true
+- `path` - The path to your custom plugin directory. Defaults to a directory named 'ohai_plugins' in the Chef config dir.
+- `source_file` - The source file for the plugin in your cookbook if not NAME.rb.
+- `resource` - The resource type for the plugin file. Either `:cookbook_file` or `:template`. Defaults to `:cookbook_file`.
+- `variables` - Usable only if `resource` is `:template`. Defines the template's variables.
+- `compile_time` - Should the resource run at compile time. This defaults to `true`.
 
 #### examples
 
@@ -89,6 +91,16 @@ Installation where the resource doesn't match the filename and you install to a 
 ohai_plugin 'My Ohai Plugin' do
   name 'my_custom_plugin'
   path '/my/custom/path/'
+end
+```
+
+Installation using a template:
+
+```ruby
+ohai_plugin 'My Templated Plugin' do
+  name 'templated_plugin'
+  resource :template
+  variables node_type: :web_server
 end
 ```
 

--- a/test/cookbooks/ohai_test/recipes/default.rb
+++ b/test/cookbooks/ohai_test/recipes/default.rb
@@ -18,6 +18,11 @@ ohai_plugin 'another_test' do
   source_file 'another_test_source_file.rb'
 end
 
+ohai_plugin 'template_test' do
+  resource :template
+  variables(plugin_name: 'template_test')
+end
+
 # node['test'] comes from the ohai plugin
 file '/expected_file' do
   action :create

--- a/test/cookbooks/ohai_test/templates/default/template_test.rb
+++ b/test/cookbooks/ohai_test/templates/default/template_test.rb
@@ -1,0 +1,7 @@
+Ohai.plugin(:Templatetest) do
+  provides '<%= @plugin_name -%>'
+
+  collect_data do
+    template_test Mash.new
+  end
+end


### PR DESCRIPTION
### Description

- Allow template in addition to cookbook_file as an Ohai plugin source.
  Implement support for variables attribute and resource as a resource
  type chooser.
- Update documentation
- Add tests

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD