### PR TITLE
Fix ohai_plugin path attribute description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Installs custom Ohai plugins.
 #### Resource Attributes
 
 - `plugin_name` - The name to give the plugin on the filesystem. Should be string, default is name of resource.
-- `path` - The path to your custom plugin directory. Defaults to a directory named 'ohai_plugins' in the Chef config dir.
+- `path` - The path to your custom plugin directory. Defaults to a directory named 'plugins' under the directory 'ohai' in the Chef config dir.
 - `source_file` - The source file for the plugin in your cookbook if not NAME.rb.
 - `resource` - The resource type for the plugin file. Either `:cookbook_file` or `:template`. Defaults to `:cookbook_file`.
 - `variables` - Usable only if `resource` is `:template`. Defines the template's variables.


### PR DESCRIPTION
### Description

The default path is /etc/chef/ohai/plugins/, not /etc/chef/ohai_plugins/