### PR TITLE
Fix error in notifies reload for delete action.

### DIFF
--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -106,7 +106,7 @@ end
 action :delete do
   file ::File.join(desired_plugin_path, new_resource.plugin_name) do
     action :delete
-    notifies :reload, ohai[reload ohai post plugin removal]
+    notifies :reload, 'ohai[reload ohai post plugin removal]'
   end
 
   ohai 'reload ohai post plugin removal' do

--- a/test/cookbooks/ohai_test/recipes/default.rb
+++ b/test/cookbooks/ohai_test/recipes/default.rb
@@ -28,3 +28,7 @@ file '/expected_file' do
   action :create
   only_if { node['tester'] }
 end
+
+ohai_plugin 'tester' do
+  action :delete
+end


### PR DESCRIPTION
### Description

This change fixes a syntax error inside of the delete resource.
### Issues Resolved

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


