### PR TITLE
Ignore case in plugin path check on Windows

### DIFF
--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -45,7 +45,12 @@ path cannot be determined")
                         ::Ohai::Config.ohai['plugin_path'] # new format
                       end
 
-    ohai_plugin_dir.include?(desired_dir)
+    case node['platform']
+    when 'windows'
+      ohai_plugin_dir.map(&:downcase).include?(desired_dir.downcase)
+    else
+      ohai_plugin_dir.include?(desired_dir)
+    end
   end
 
   def add_to_plugin_path(path)


### PR DESCRIPTION
### Description

This allows case-insensitive checks for `#in_plugin_path?` on Windows (which is case-insensitive).

### Issues Resolved

Fixes https://github.com/chef-cookbooks/ohai/issues/47

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD