### PR TITLE
Fix typo in compile warning

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-Chef::Log.warn('The Ohai cookbook default recipe has no content has of the 4.0 release. See the readme for instructions on using the custom resources.')
+Chef::Log.warn('The Ohai cookbook default recipe has no content as of the 4.0 release. See the readme for instructions on using the custom resources.')


### PR DESCRIPTION
Currently, including the ohai cookbook generates the following log entry when compiling cookbooks:
```
WARN: The Ohai cookbook default recipe has no content has of the 4.0 release. See the readme for instructions on using the custom resources.
```

s/has no content has of/has no content as of/

