### PR TITLE
Add a recipe for lsb

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,3 +38,13 @@ suites:
 - name: default
   run_list:
     - recipe[ohai_test::default]
+- name: lsb
+  run_list:
+    - recipe[ohai::lsb]
+  verifier:
+    inspec_tests:
+      - test/recipes
+  includes:
+    - centos-7.2
+    - debian-8.5
+    - ubuntu-16.04

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Contains custom resources for adding Ohai hints and installing custom Ohai plugi
 
 - compat_resource
 
+## Recipes
+
+### `lsb`
+
+Install requirements to use `node['lsb']` attributes.
+
 ## Custom Resources (Providers)
 
 ### `ohai_hint`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,4 @@
+default['ohai']['lsb']['package'] = value_for_platform_family(
+  'debian' => 'lsb-release',
+  %w(rhel fedora) => 'redhat-lsb'
+)

--- a/recipes/lsb.rb
+++ b/recipes/lsb.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: ohai
+# Recipe:: lsb
+#
+# Copyright (c) 2016 Chef Software, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package node['ohai']['lsb']['package'] do
+  action :install
+  notifies :reload, 'ohai[lsb]', :immediately
+end
+
+ohai 'lsb' do
+  action :nothing
+end

--- a/test/recipes/lsb.rb
+++ b/test/recipes/lsb.rb
@@ -1,0 +1,7 @@
+# # encoding: utf-8
+
+# Inspec test for recipe ohai::lsb
+
+describe command('/usr/bin/lsb_release') do
+  it { should exist }
+end


### PR DESCRIPTION
### Description

Add a recipe `ohai::lsb`

### Issues Resolved

If `lsb_release` isn't available, using `node['lsb']['*']` can fail with an error

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Install all we need for node['lsb'] attributes to be used