### PR TITLE
AWS OpsWorks doesn’t like chef_version.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,4 @@ depends 'compat_resource', '>= 12.14'
 source_url 'https://github.com/chef-cookbooks/ohai'
 issues_url 'https://github.com/chef-cookbooks/ohai/issues'
 
-chef_version '>= 12.1'
+chef_version '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Safely call chef_version in AWS OpsWorks

### Issues Resolved

n/a

### Check List

- [+] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [+] New functionality includes testing.
- [-] New functionality has been documented in the README if applicable
- [-] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Mark Hudson <mark.hudson@ignitionwealth.com>