### PR TITLE
Chef 13 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,11 +18,11 @@ platforms:
   - name: fedora-25
   - name: opensuse-leap-42.2
   - name: ubuntu-14.04
-  - name: ubuntu-14.04-chef125
+  - name: ubuntu-14.04-chef127
     driver_config:
       box: bento/ubuntu-14.04
     provisioner:
-      require_chef_omnibus: 12.5.1
+      require_chef_omnibus: 12.7.2
   - name: ubuntu-16.04
   - name: windows-2008r2
     driver_config:

--- a/resources/hint.rb
+++ b/resources/hint.rb
@@ -2,9 +2,9 @@ property :hint_name, kind_of: String, name_attribute: true
 property :content, kind_of: Hash
 property :compile_time, [true, false], default: true
 
-action_class.class_eval do
+action_class do
   def ohai_hint_path
-    path = ::File.join(::Ohai::Config[:hints_path].first, new_resource.hint_name)
+    path = ::File.join(::Ohai::Config.ohai.hints_path.first, new_resource.hint_name)
     path << '.json' unless path.end_with?('.json')
     path
   end
@@ -24,7 +24,7 @@ action_class.class_eval do
 end
 
 action :create do
-  directory ::Ohai::Config[:hints_path].first do
+  directory ::Ohai::Config.ohai.hints_path.first do
     action :create
     recursive true
   end

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -6,14 +6,14 @@ property :resource, [:cookbook_file, :template], default: :cookbook_file
 property :variables, kind_of: Hash
 property :compile_time, [true, false], default: true
 
-action_class.class_eval do
+action_class do
   # return the path property if specified or
   # CHEF_CONFIG_PATH/ohai/plugins if a path isn't specified
   def desired_plugin_path
-    if path
-      path
+    if new_resource.path
+      new_resource.path
     else
-      ohai_plugin_path
+      ::File.join(chef_config_path, 'ohai', 'plugins')
     end
   end
 
@@ -28,37 +28,21 @@ path cannot be determined")
     end
   end
 
-  # return the ohai plugin path. Most likely /etc/chef/ohai/plugins/
-  def ohai_plugin_path
-    ::File.join(chef_config_path, 'ohai', 'plugins')
-  end
-
   # is the desired plugin dir in the ohai config plugin dir array?
   def in_plugin_path?(path)
     # get the directory where we plan to stick the plugin (not the actual file path)
     desired_dir = ::File.directory?(path) ? path : ::File.dirname(path)
 
-    # get the array of plugin paths Ohai knows about
-    ohai_plugin_dir = if ::Ohai::Config.ohai.nil?
-                        ::Ohai::Config['plugin_path'] # old format
-                      else
-                        ::Ohai::Config.ohai['plugin_path'] # new format
-                      end
-
     case node['platform']
     when 'windows'
-      ohai_plugin_dir.map(&:downcase).include?(desired_dir.downcase)
+      ::Ohai::Config.ohai['plugin_path'].map(&:downcase).include?(desired_dir.downcase)
     else
-      ohai_plugin_dir.include?(desired_dir)
+      ::Ohai::Config.ohai['plugin_path'].include?(desired_dir)
     end
   end
 
   def add_to_plugin_path(path)
-    if ::Ohai::Config.ohai.nil?
-      ::Ohai::Config['plugin_path'] << path # old format
-    else
-      ::Ohai::Config.ohai['plugin_path'] << path # new format
-    end
+    ::Ohai::Config.ohai['plugin_path'] << path # new format
   end
 
   # we need to warn the user that unless the path for this plugin is in Ohai's


### PR DESCRIPTION
Use the new config format everywhere and remove the old backwards compatibility code since the new config was introduced in Chef 12.6 and we require 12.7 or later. Also update the test kitchen config to test on 12.7.2.

Signed-off-by: Tim Smith <tsmith@chef.io>