### PR TITLE
Add the load_single_plugin option to the ohai_plugin resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ NOTE: The ohai_hint resource shipped in Chef 14.0 (April 2018). When Chef 15.0 i
 
 Creates Ohai hint files, which are consumed by Ohai plugins in order to determine if they should run or not.
 
-#### Resource Attributes
+#### Resource Properties
 
 - `hint_name` - The name of hints file and key. Should be string, default is name of resource.
 - `content` - Values of hints. It will be used as automatic attributes. Should be Hash, default is empty Hash
@@ -71,7 +71,7 @@ You can check for the creation or deletion of ohai hints with chefspec using the
 
 Installs custom Ohai plugins.
 
-#### Resource Attributes
+#### Resource Properties
 
 - `plugin_name` - The name to give the plugin on the filesystem. Should be string, default is name of resource.
 - `path` - The path to your custom plugin directory. Defaults to a directory named 'plugins' under the directory 'ohai' in the Chef config dir.
@@ -80,6 +80,7 @@ Installs custom Ohai plugins.
 - `resource` - The resource type for the plugin file. Either `:cookbook_file` or `:template`. Defaults to `:cookbook_file`.
 - `variables` - Usable only if `resource` is `:template`. Defines the template's variables.
 - `compile_time` - Should the resource run at compile time. This defaults to `true`.
+- `load_single_plugin` - Reload all plugins unless this value is set to true. Load only the named plugin.
 
 #### examples
 

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -5,6 +5,7 @@ property :cookbook, String
 property :resource, [:cookbook_file, :template], default: :cookbook_file
 property :variables, Hash
 property :compile_time, [true, false], default: true
+property :load_single_plugin, [true, false], default: false
 
 action :create do
   # why create_if_missing you ask?
@@ -42,6 +43,7 @@ action :create do
   ohai new_resource.plugin_name do
     action :nothing
     action :reload if reload_required
+    plugin new_resource.plugin_name if new_resource.load_single_plugin
   end
 end
 

--- a/test/cookbooks/ohai_test/files/test_status.rb
+++ b/test/cookbooks/ohai_test/files/test_status.rb
@@ -1,0 +1,8 @@
+Ohai.plugin(:TestStatus) do
+  provides 'test_status'
+
+  collect_data do
+    test_status Mash.new
+    test_status['status'] = ::File.read('/status')
+  end
+end

--- a/test/cookbooks/ohai_test/files/tester1.rb
+++ b/test/cookbooks/ohai_test/files/tester1.rb
@@ -1,0 +1,7 @@
+Ohai.plugin(:Tester1) do
+  provides 'tester1'
+
+  collect_data do
+    tester1 Mash.new
+  end
+end

--- a/test/cookbooks/ohai_test/recipes/default.rb
+++ b/test/cookbooks/ohai_test/recipes/default.rb
@@ -35,3 +35,49 @@ end
 ohai_plugin 'tester' do
   action :delete
 end
+
+file 'Initial status file' do
+  path '/status'
+  content 'Initial'
+end.run_action(:create)
+
+ohai_plugin 'load test_status' do
+  plugin_name 'test_status'
+end
+
+ruby_block 'save loaded status' do
+  block do
+    ::File.write('/status', node['test_status'].inspect)
+  end
+end.run_action(:run)
+
+file 'Next status' do
+  path '/status'
+  content 'Second'
+end.run_action(:create)
+
+ohai_plugin 'Tester and reload all plugins' do
+  plugin_name 'tester'
+end
+
+ruby_block 'save loaded status second time' do
+  block do
+    ::File.write('/status2', node['test_status'].inspect)
+  end
+end.run_action(:run)
+
+file 'Third status' do
+  path '/status'
+  content 'Updated by tester1 load'
+end.run_action(:create)
+
+ohai_plugin 'Install Tester1 and load only tester1' do
+  plugin_name 'tester1'
+  load_single_plugin true
+end
+
+ruby_block 'save loaded status third time' do
+  block do
+    ::File.write('/status3', node['test_status'].inspect)
+  end
+end.run_action(:run)

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -25,3 +25,16 @@ end
 describe file('/expected_file') do
   it { should be_file }
 end
+
+# Shows that running with load_single_plugin does not reload all of the plugins
+describe file('/status') do
+  its(:content) { should match /Updated by tester1 load/ }
+end
+
+describe file('/status2') do
+  its(:content) { should match /status\"=>\"Second/ }
+end
+
+describe file('/status3') do
+  its(:content) { should match /status\"=>\"Second/ }
+end


### PR DESCRIPTION
By default the ohai resource reloads all plugins when adding a plugin.
The load_single_plugin option allows a plugin to be added and
to have only that plugin be loaded. Adding many plugins is a slow process if
all of the plugins are reloaded multiple times.

### Description

Adds an option that reduces server build time.

### Issues Resolved

No issues resolved.  

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
